### PR TITLE
YT-48 유저는 watch 페이지에서 메뉴 버튼을 클릭하여 drawerSidebar 를 확인할 수 있다.

### DIFF
--- a/src/views/shared/components/Header/Gnb/index.js
+++ b/src/views/shared/components/Header/Gnb/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { MdMenu } from 'react-icons/all';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { useMediaMatch } from 'rooks';
 
@@ -15,8 +15,10 @@ const Gnb = () => {
   const small = useMediaMatch('(max-width: 1000px)');
   const normalSidebar = useSelector((state) => state.app.normalSidebar)
   const drawerSidebar = useSelector((state) => state.app.drawerSidebar)
+  const location = useLocation()
+
   const onClick = () => {
-    if (small) {
+    if (small || location.pathname.startsWith('/watch/')) {
       dispatch(handleDrawerSidebar(!drawerSidebar))
     } else {
       dispatch(handleNormalSidebar(!normalSidebar))


### PR DESCRIPTION
- watch 페이지에서 drawserSidebar 안 불러지는 오류를 Gnb 컴포넌트에서 수정함